### PR TITLE
27 fix puppeteer chrome setup for visual tests in ci

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -29,10 +29,9 @@ jobs:
 
       - name: Install Puppeteer Chrome
         run: |
-          set -o pipefail
           rm -rf "$PUPPETEER_CACHE_DIR/chrome"
-          npx puppeteer browsers install chrome --format '{{path}}' | tee puppeteer-chrome-path.txt
-          CHROME_PATH="$(tail -n 1 puppeteer-chrome-path.txt)"
+          npx puppeteer browsers install chrome
+          CHROME_PATH="$(node --input-type=module -e "import puppeteer from 'puppeteer'; console.log(puppeteer.executablePath());")"
           if [ ! -x "$CHROME_PATH" ]; then
             echo "::error::Puppeteer Chrome executable was not found at $CHROME_PATH"
             find "$PUPPETEER_CACHE_DIR" -maxdepth 5 -type f -name chrome -print

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -26,7 +26,9 @@ jobs:
         run: npm ci
 
       - name: Install Puppeteer Chrome
-        run: npx puppeteer browsers install chrome
+        run: |
+          rm -rf ~/.cache/puppeteer/chrome
+          npx puppeteer browsers install chrome
 
       - name: Build bundle
         run: npm run build

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -29,9 +29,16 @@ jobs:
 
       - name: Install Puppeteer Chrome
         run: |
+          set -o pipefail
           rm -rf "$PUPPETEER_CACHE_DIR/chrome"
-          CHROME_PATH="$(npx puppeteer browsers install chrome --format '{{path}}')"
-          test -x "$CHROME_PATH"
+          npx puppeteer browsers install chrome --format '{{path}}' | tee puppeteer-chrome-path.txt
+          CHROME_PATH="$(tail -n 1 puppeteer-chrome-path.txt)"
+          if [ ! -x "$CHROME_PATH" ]; then
+            echo "::error::Puppeteer Chrome executable was not found at $CHROME_PATH"
+            find "$PUPPETEER_CACHE_DIR" -maxdepth 5 -type f -name chrome -print
+            exit 1
+          fi
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
           echo "Installed Puppeteer Chrome at $CHROME_PATH"
 
       - name: Build bundle
@@ -42,7 +49,7 @@ jobs:
 
       - name: Upload visual diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-diff-images
           path: |

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -11,8 +11,6 @@ jobs:
   visual-regression:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
 
     steps:
       - name: Check out repository
@@ -27,18 +25,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Puppeteer Chrome
+      - name: Resolve Puppeteer Chrome version
+        id: puppeteer-chrome
         run: |
-          rm -rf "$PUPPETEER_CACHE_DIR/chrome"
-          npx puppeteer browsers install chrome
-          CHROME_PATH="$(node --input-type=module -e "import puppeteer from 'puppeteer'; console.log(puppeteer.executablePath());")"
+          CHROME_VERSION="$(node -e "console.log(require('puppeteer-core/internal/revisions.js').PUPPETEER_REVISIONS.chrome)")"
+          echo "version=$CHROME_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using Puppeteer Chrome $CHROME_VERSION"
+
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: ${{ steps.puppeteer-chrome.outputs.version }}
+
+      - name: Configure Puppeteer Chrome
+        run: |
+          CHROME_PATH="${{ steps.setup-chrome.outputs.chrome-path }}"
           if [ ! -x "$CHROME_PATH" ]; then
             echo "::error::Puppeteer Chrome executable was not found at $CHROME_PATH"
-            find "$PUPPETEER_CACHE_DIR" -maxdepth 5 -type f -name chrome -print
             exit 1
           fi
+          "$CHROME_PATH" --version
           echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
-          echo "Installed Puppeteer Chrome at $CHROME_PATH"
+          echo "Configured Puppeteer Chrome at $CHROME_PATH"
 
       - name: Build bundle
         run: npm run build

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -11,6 +11,8 @@ jobs:
   visual-regression:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
 
     steps:
       - name: Check out repository
@@ -27,8 +29,10 @@ jobs:
 
       - name: Install Puppeteer Chrome
         run: |
-          rm -rf ~/.cache/puppeteer/chrome
-          npx puppeteer browsers install chrome
+          rm -rf "$PUPPETEER_CACHE_DIR/chrome"
+          CHROME_PATH="$(npx puppeteer browsers install chrome --format '{{path}}')"
+          test -x "$CHROME_PATH"
+          echo "Installed Puppeteer Chrome at $CHROME_PATH"
 
       - name: Build bundle
         run: npm run build

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Puppeteer Chrome
+        run: npx puppeteer browsers install chrome
+
       - name: Build bundle
         run: npm run build
 


### PR DESCRIPTION
- fix visual regression CI by installing the Puppeteer Chrome version explicitly
- pass the resolved Chrome path to Puppeteer via `PUPPETEER_EXECUTABLE_PATH`
- update `actions/upload-artifact` to v7 for Node.js 24 compatibility